### PR TITLE
Mount auth hook on '/api'

### DIFF
--- a/v4/securing-google-auth/google-auth-hook.js
+++ b/v4/securing-google-auth/google-auth-hook.js
@@ -69,13 +69,13 @@ function enableGoogleOauth(app, config, services) {
         },
     );
 
-    app.use('/api/admin/', (req, res, next) => {
+    app.use('/api', (req, res, next) => {
         if (req.user) {
             return next();
         }
         // Instruct unleash-frontend to pop-up auth dialog
         return res
-            .status('401')
+            .status(401)
             .json(
                 new AuthenticationRequired({
                     path: '/api/admin/login',


### PR DESCRIPTION
From #56 we learned that our auth hooks needs to be mounted on `/api` if we want to protect our client endpoint as well.
The api token middleware only authenticates, it passes authorization down the chain.

This PR fixes the same for our google-auth example as #57 does for our keycloak example