### PR TITLE
task: Update to most recent unleash

### DIFF
--- a/v4/inprocess-proxy/package.json
+++ b/v4/inprocess-proxy/package.json
@@ -13,8 +13,8 @@
     "start": "node dist/start.js"
   },
   "dependencies": {
-    "@unleash/proxy": "^0.8.0",
-    "unleash-server": "^4.9.1",
+    "@unleash/proxy": "^0.8.1",
+    "unleash-server": "^4.12.6",
     "winston": "^3.7.2"
   },
   "devDependencies": {

--- a/v4/securing-azure-auth/azure-auth-hook.js
+++ b/v4/securing-azure-auth/azure-auth-hook.js
@@ -74,12 +74,12 @@ function azureAdminOauth(app, config, services) {
     }
   );
 
-  app.use('/api/admin/', (req, res, next) => {
+  app.use('/api', (req, res, next) => {
     if (req.user) {
       next();
     } else {
       return res
-        .status('401')
+        .status(401)
         .json(
           new unleash.AuthenticationRequired({
             path: '/auth/azure/login',

--- a/v4/securing-azure-auth/package.json
+++ b/v4/securing-azure-auth/package.json
@@ -10,8 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "@passport-next/passport": "^3.1.0",
-    "passport": "^0.4.1",
-    "passport-azure-ad": "^4.3.1",
-    "unleash-server": "^4.0.0-beta.5"
+    "passport": "^0.6.0",
+    "passport-azure-ad": "^4.3.3",
+    "unleash-server": "^4.12.6"
   }
 }

--- a/v4/securing-basic-auth/package.json
+++ b/v4/securing-basic-auth/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "unleash-server": "^4.0.0-beta.5"
+    "unleash-server": "^4.12.6"
   }
 }

--- a/v4/securing-google-auth/package.json
+++ b/v4/securing-google-auth/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@passport-next/passport": "^3.1.0",
     "@passport-next/passport-google-oauth2": "^1.0.0",
-    "unleash-server": "^4.0.0-beta.5"
+    "unleash-server": "^4.12.6"
   }
 }


### PR DESCRIPTION
This PR updates unleash-server to the most recently released one in the examples, rather than an early 4.0.0-beta.
Started from #56 - which pointed out that our examples did not protect the /api/client/* endpoints.