### PR TITLE
task: Pin unleashversion to 3 in all v3 projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     {
       "matchPaths": ["v3/"],
       "matchPackageNames": ["unleash-server"],
-      "allowedVersions": "<=3.17.6"
+      "allowedVersions": "< 4"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPaths": ["v3/"],
+      "matchPackageNames": ["unleash-server"],
+      "allowedVersions": "<=3.17.6"
+    }
   ]
 }


### PR DESCRIPTION
So, since we just applied renovatebot to this repo, we also need to make sure it does not upgrade unleash-server to v4 in our v3 examples. From 
* https://docs.renovatebot.com/configuration-options/#allowedversions
* https://docs.renovatebot.com/configuration-options/#matchpaths
* https://docs.renovatebot.com/configuration-options/#matchpackagenames

this seems like it should apply to our v3 folders