### PR TITLE
fix: update keycloak userInfoUrl

### DIFF
--- a/v4/securing-keycloak-auth/keycloak-auth-hook.js
+++ b/v4/securing-keycloak-auth/keycloak-auth-hook.js
@@ -42,7 +42,7 @@ function enableKeycloakOauth(app, config, services) {
                 callbackURL: `${contextPath}/api/auth/callback`,
                 authorizationURL: `${host}/realms/${realm}/protocol/openid-connect/auth`,
                 tokenURL: `${host}/realms/${realm}/protocol/openid-connect/token`,
-                userInfoURL: `${host}/auth/realms/${realm}/protocol/openid-connect/userinfo`,
+                userInfoURL: `${host}/realms/${realm}/protocol/openid-connect/userinfo`,
             },
     
             async (accessToken, refreshToken, profile, done) => {


### PR DESCRIPTION
## About the changes
Doing some testing https://github.com/Unleash/unleash-examples/pull/121 we realized that the configured URL for user info does not exist and this leads to a 404 error.

In order for the test to work the master realm in keycloak has to be modified to allow redirects to `http://localhost:4242/*` and the admin account have an email