### PR TITLE
Update google auth hook to use passport-google-oidc instead of passpo…

### DIFF
--- a/v4/securing-google-auth/google-auth-hook.js
+++ b/v4/securing-google-auth/google-auth-hook.js
@@ -20,8 +20,7 @@
  */
 
 const passport = require('@passport-next/passport');
-const GoogleOAuth2Strategy = require('@passport-next/passport-google-oauth2')
-    .Strategy;
+const GoogleStrategy = require('passport-google-oidc'):
 
 const  { AuthenticationRequired } = require('unleash-server');
 
@@ -30,14 +29,14 @@ function enableGoogleOauth(app, config, services) {
     const { userService } = services;
 
     passport.use(
-        new GoogleOAuth2Strategy(
+        new Googletrategy(
             {
                 clientID: process.env.GOOGLE_CLIENT_ID,
                 clientSecret: process.env.GOOGLE_CLIENT_SECRET,
                 callbackURL: process.env.GOOGLE_CALLBACK_URL,
             },
-    
-            async (accessToken, refreshToken, profile, done) => {
+
+            async (issuer, profile, done) => {
                 const email  = profile.emails[0].value;
                 const user = await userService.loginUserWithoutPassword(email, true);
                 done(


### PR DESCRIPTION
## About the changes

Following this [ticket](https://github.com/Unleash/unleash-docker-community/issues/155) in `unleash-docker-community` project, Google auth hook needs to be updating because use of `passport-google-oauth2` library has been replaced by `passport-google-oidc` one

## Discussion points
I didn't know if I had to update documentation header of the modified file, so feel free to modify it if relevant.
