### PR TITLE
fix: 🐛 fix syntax error in google auth example

### DIFF
--- a/v4/securing-google-auth/google-auth-hook.js
+++ b/v4/securing-google-auth/google-auth-hook.js
@@ -20,7 +20,7 @@
  */
 
 const passport = require('@passport-next/passport');
-const GoogleStrategy = require('passport-google-oidc'):
+const GoogleStrategy = require('passport-google-oidc');
 
 const  { AuthenticationRequired } = require('unleash-server');
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

We noticed this syntax error when upgrading to Unleash 6.x.