### PR TITLE
fix: correct typo

### DIFF
--- a/v4/securing-google-auth/google-auth-hook.js
+++ b/v4/securing-google-auth/google-auth-hook.js
@@ -29,7 +29,7 @@ function enableGoogleOauth(app, config, services) {
     const { userService } = services;
 
     passport.use(
-        new Googletrategy(
+        new GoogleStrategy(
             {
                 clientID: process.env.GOOGLE_CLIENT_ID,
                 clientSecret: process.env.GOOGLE_CLIENT_SECRET,


### PR DESCRIPTION
These examples should probably have at least ESLint set up to avoid these sorts of errors?